### PR TITLE
imrprove deny access to hidden files/directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,8 +959,8 @@ location ~* ^.*(\.(?:git|svn|htaccess))$ {
 
 }
 
-# or all . directories/files in general (but remember about .well-known path)
-location ~ /\. {
+# or all . directories/files excepted .well-known
+location ~ /\.(?!well-known\/) {
 
   deny all;
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ Hardening checklist based on this recipes (@ssllabs A+ 100%) - High-Res 5000x820
 <p>
 &nbsp;&nbsp;:black_small_square: <a href="https://gist.github.com/carlessanagustin/9509d0d31414804da03b"><b>Nginx Cheatsheet</b></a><br>
 &nbsp;&nbsp;:black_small_square: <a href="https://github.com/SimulatedGREG/nginx-cheatsheet"><b>Nginx Quick Reference</b></a><br>
-&nbsp;&nbsp;:black_small_square: <a href="https://mijndertstuij.nl/writing/posts/nginx-cheatsheet/"><b>Nginx Cheatsheet by Mijdert Stuij</b></a><br>
 </p>
 
 ##### Performance & Hardening


### PR DESCRIPTION
* Exclude .well-known in the directive used to deny access to hidden files/directories
* Removing cheatsheet dead link